### PR TITLE
setup initialization for woocommerce default page

### DIFF
--- a/woocommerce-filters.php
+++ b/woocommerce-filters.php
@@ -72,7 +72,7 @@ class BeRocket_AAPF {
         if( $query->is_main_query() and
 		    ( $query->get( 'post_type' ) == 'product' or $query->get( 'product_cat' ) )
 			or
-			$query->is_page() && 'page' == get_option( 'show_on_front' ) && $query->get('page_id') == wc_get_page_id('shop')
+			$query->is_page() && 'page' == get_option( 'show_on_front' ) && $query->queried_object_id == wc_get_page_id('shop')
 		){
             br_aapf_args_converter();
 			$args = br_aapf_args_parser();


### PR DESCRIPTION
by previously filter user server-side does not make filter this is small fix  
$query->get('page_id') return 0 and $query->queried_object_id worked for me/
i hope work for every one
i am using WP 4.2
