### PR TITLE
Adding '/' to end of url

### DIFF
--- a/js/widget.min.js
+++ b/js/widget.min.js
@@ -95,7 +95,7 @@
                     if( ! parseInt( cur_page ) ){
                         cur_page = prev_page;
                     }
-                    args.location = args.location.replace(/\/?/,"") + "?page=" + cur_page + "";
+                    args.location = args.location.replace(/\/?/,"") + "/?page=" + cur_page + "";
                 }
             }
 
@@ -181,7 +181,7 @@
                 }
                 uri = uri.replace(/\/?$/,"") + "/page/" + cur_page + "/";
                 if( uri_request ){
-                    uri = uri + "?filters=" + uri_request;
+                    uri = uri + "/?filters=" + uri_request;
                 }
             }else{
                 something_added = false;
@@ -222,12 +222,12 @@
                         uri = uri + "&paged=" + parseInt( cur_page );
                     }
                 }else if( uri_request ){
-                    uri = uri + "?filters=" + uri_request;
+                    uri = uri + "/?filters=" + uri_request;
                     if( cur_page > 1 ){
                         uri = uri + "&paged=" + parseInt( cur_page );
                     }
                 }else if( cur_page > 1 ){
-                    uri = uri + "?paged=" + parseInt( cur_page );
+                    uri = uri + "/?paged=" + parseInt( cur_page );
                 }
             }
 


### PR DESCRIPTION
by adding '/' to end of url ( before get query ) allow users to copy and past url, 
by default when url has not '/' and start by "?" ( get query ) wordpress add '/' automatically and remove '^' and '|' that makes filters wont work any more.
i am using WP 4.2
